### PR TITLE
Fix NuGet package metadata for accurate package description

### DIFF
--- a/src/LayeredCraft.Lambda.AspNetCore.HostingExtensions/LayeredCraft.Lambda.AspNetCore.HostingExtensions.csproj
+++ b/src/LayeredCraft.Lambda.AspNetCore.HostingExtensions/LayeredCraft.Lambda.AspNetCore.HostingExtensions.csproj
@@ -8,8 +8,8 @@
         <LangVersion>default</LangVersion>
         <PackageId>LayeredCraft.Lambda.AspNetCore.HostingExtensions</PackageId>
         <Title>LayeredCraft.Lambda.AspNetCore.HostingExtensions</Title>
-        <Description>Provides reusable AWS CDK constructs for serverless .NET applications, including Lambda functions with OpenTelemetry, IAM roles, and environment configuration. Built for LayeredCraft projects using AWS CDK in C#.</Description>
-        <PackageTags>aws;cdk;lambda;constructs;dotnet;opentelemetry;infrastructure;cloudformation;layeredcraft</PackageTags>
+        <Description>ASP.NET Core hosting extensions for AWS Lambda, providing timeout-aware cancellation tokens and graceful request handling. Links Lambda timeout detection with HTTP request cancellation for improved reliability and proper resource cleanup in serverless applications.</Description>
+        <PackageTags>aws;lambda;aspnetcore;hosting;middleware;timeout;cancellation;serverless;dotnet;layeredcraft</PackageTags>
         <PackageIcon>icon.png</PackageIcon>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary
- Corrects inaccurate NuGet package metadata that incorrectly described AWS CDK constructs
- Updates Description to accurately reflect Lambda timeout handling and ASP.NET Core hosting functionality
- Fixes PackageTags to include relevant middleware, serverless, and hosting terms

## Changes
- **Description**: Changed from AWS CDK constructs description to accurate ASP.NET Core Lambda hosting extensions description
- **PackageTags**: Updated from CDK-related tags to ASP.NET Core, Lambda, middleware, and serverless tags

## Impact
- Improves package discoverability on NuGet.org with accurate metadata
- Ensures developers can find this package when searching for Lambda hosting solutions
- Eliminates confusion about package purpose and functionality

🤖 Generated with [Claude Code](https://claude.ai/code)