### PR TITLE
ci(github): use app token for dependabot merges

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Generate app token
         id: app-token
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.DEPENDABOT_AUTOMERGE_APP_ID }}
           private-key: ${{ secrets.DEPENDABOT_AUTOMERGE_PRIVATE_KEY }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,16 +19,24 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      - name: Generate app token
+        id: app-token
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.DEPENDABOT_AUTOMERGE_APP_ID }}
+          private-key: ${{ secrets.DEPENDABOT_AUTOMERGE_PRIVATE_KEY }}
+
       - name: Approve PR
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Updates the Dependabot auto-merge workflow to use the LayeredCraft GitHub App token for approving and enabling auto-merge. This avoids using `GITHUB_TOKEN` for the merge operation so downstream workflows can run after Dependabot auto-merged changes land on `main`.

## Changes

- Adds `actions/create-github-app-token@v2` to mint an installation token for patch/minor Dependabot PRs.
- Uses the app token as `GH_TOKEN` for `gh pr review --approve` and `gh pr merge --auto --squash`.
- Keeps `dependabot/fetch-metadata` on the default `GITHUB_TOKEN`.

## Validation

- Reviewed workflow syntax and token usage.
- No build required; workflow-only change.

## Notes for Reviewers

Requires the Actions secrets `DEPENDABOT_AUTOMERGE_APP_ID` and `DEPENDABOT_AUTOMERGE_PRIVATE_KEY` to be available to this repository.
