### PR TITLE
ci(github): use bracket notation for app token

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -32,11 +32,11 @@ jobs:
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps['app-token'].outputs.token }}
 
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps['app-token'].outputs.token }}


### PR DESCRIPTION
## Summary

Updates the Dependabot auto-merge workflow to reference the GitHub App token output with bracket notation. This avoids ambiguity around the hyphenated `app-token` step ID in GitHub Actions expressions.

## Changes

- Replaces `steps.app-token.outputs.token` with `steps['app-token'].outputs.token` for the approve and auto-merge steps.

## Validation

- Workflow-only change; reviewed expression syntax.
